### PR TITLE
Corrected page size for rest calls

### DIFF
--- a/src/main/java/org/dasein/cloud/digitalocean/models/rest/DigitalOceanModelFactory.java
+++ b/src/main/java/org/dasein/cloud/digitalocean/models/rest/DigitalOceanModelFactory.java
@@ -67,8 +67,9 @@ public class DigitalOceanModelFactory {
             logger.trace("ENTER - " + DigitalOceanModelFactory.class.getName() + ".performHttpRequest(" + method + "," + token + "," + endpoint + "," + timeout+ ")");
         }
 
-        //Ignore pagination use of per_page=-1 for all requests
-        String strUrl = endpoint + "?per_page=-1";
+        // Ignore pagination use of per_page=-1 for all requests
+        // String strUrl = endpoint + "?per_page=-1";
+        String strUrl = endpoint + "?per_page=50000";
 
         if( logger.isTraceEnabled() ) {
             logger.trace("CALLING - " + method + " "  + endpoint);


### PR DESCRIPTION
-1 is an invalid value, defaults to 20 records per page.  50000 should be enough to get us through testing, light use.